### PR TITLE
Added python API for getting address of Wiimote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Minor changed Copyright (C) 2020 Alexander Pruss
+Python3 adaptation (c) by Azzra https://github.com/azzra
 Copyright (C) 2007 L. Donnie Smith <cwiid@abstrakraft.org>
 Copyright (C) 2011-2015 Ivica Ico Bukvic <ico@vt.edu> and Deba Pratim Saha <dpsaha@vt.edu>
 

--- a/configure
+++ b/configure
@@ -667,6 +667,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -748,6 +749,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1000,6 +1002,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1137,7 +1148,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1290,6 +1301,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -3118,7 +3130,7 @@ if test "${with_python+set}" = set; then :
   withval=$with_python; case $withval in
 		yes)
 			REQUIRE_PYTHON=1
-			PYTHON_NAME=python
+			PYTHON_NAME=python3
 		;;
 		no)
 			REQUIRE_PYTHON=
@@ -3130,7 +3142,7 @@ if test "${with_python+set}" = set; then :
 		;;
 	esac
 else
-  REQUIRE_PYTHON=1; PYTHON_NAME=python
+  REQUIRE_PYTHON=1; PYTHON_NAME=python3
 fi
 
 if test $REQUIRE_PYTHON; then

--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ AC_ARG_WITH(
 	[case $withval in 
 		yes)
 			REQUIRE_PYTHON=1
-			PYTHON_NAME=python
+			PYTHON_NAME=python3
 		;;
 		no)
 			REQUIRE_PYTHON=
@@ -61,7 +61,7 @@ AC_ARG_WITH(
 			PYTHON_NAME=$withval
 		;;
 	esac],
-	[REQUIRE_PYTHON=1; PYTHON_NAME=python])
+	[REQUIRE_PYTHON=1; PYTHON_NAME=python3])
 if test $REQUIRE_PYTHON; then
 	AC_CHECK_PROGS([PYTHON],$PYTHON_NAME)
 	if test $REQUIRE_PYTHON -a ! $PYTHON; then

--- a/python/Makefile.in
+++ b/python/Makefile.in
@@ -7,13 +7,13 @@ ifdef ROOTDIR
 endif
 
 all:
-	$(PYTHON) setup.py build_ext $(DEBUGFLAGS) -I@top_builddir@/libcwiid -L@top_builddir@/libcwiid -lcwiid
+	$(PYTHON) setup.py build_ext $(DEBUGFLAGS) -I@top_builddir@/libcwiid -L@top_builddir@/libcwiid
 
 install:
-	$(PYTHON) setup.py install --install-lib=${libdir}/python@PYTHON_VERSION@/site-packages $(SET_ROOT_DIR)
+	$(PYTHON) setup.py install --record installed_files.txt
 
 uninstall:
-	rm -f $(ROOTDIR)${libdir}/python@PYTHON_VERSION@/site-packages/cwiid.so
+	cat installed_files.txt | xargs rm -rf
 
 clean:
 	rm -rf build

--- a/python/Wiimote.c
+++ b/python/Wiimote.c
@@ -561,6 +561,7 @@ static PyObject *Wiimote_get_state(Wiimote* self, void *closure)
 		break;
 	case CWIID_EXT_MOTIONPLUS:
 		if (state.rpt_mode & CWIID_RPT_MOTIONPLUS) {
+#ifdef CWIID_RPT_NUNCHUK_MOTIONPLUS_PASSTHROUGH	
 			PyExt = Py_BuildValue("{s:(I,I,I),s:(I,I,I)}",
 		                          "angle_rate",
                                   state.ext.motionplus.angle_rate[CWIID_PHI],
@@ -570,6 +571,13 @@ static PyObject *Wiimote_get_state(Wiimote* self, void *closure)
                                   state.ext.motionplus.low_speed[CWIID_PHI],
                                   state.ext.motionplus.low_speed[CWIID_THETA],
                                   state.ext.motionplus.low_speed[CWIID_PSI]);
+#else
+			PyExt = Py_BuildValue("{s:(I,I,I)}",
+		                          "angle_rate",
+                                  state.ext.motionplus.angle_rate[CWIID_PHI],
+                                  state.ext.motionplus.angle_rate[CWIID_THETA],
+                                  state.ext.motionplus.angle_rate[CWIID_PSI]);
+#endif
 
 			if (!PyExt) {
 				Py_DECREF(PyState);
@@ -1014,6 +1022,7 @@ PyObject *ConvertMesgArray(int mesg_count, union cwiid_mesg mesg[])
 			               mesg[i].balance_mesg.left_bottom);
 			break;
 		case CWIID_MESG_MOTIONPLUS:
+#ifdef CWIID_RPT_NUNCHUK_MOTIONPLUS_PASSTHROUGH	
 			mesgVal = Py_BuildValue("{s:(I,I,I),s:(I,I,I)}",
 			                        "angle_rate",
                                     mesg[i].motionplus_mesg.angle_rate[CWIID_PHI],
@@ -1023,6 +1032,13 @@ PyObject *ConvertMesgArray(int mesg_count, union cwiid_mesg mesg[])
                                     mesg[i].motionplus_mesg.low_speed[CWIID_PHI],
                                     mesg[i].motionplus_mesg.low_speed[CWIID_THETA],
                                     mesg[i].motionplus_mesg.low_speed[CWIID_PSI]);
+#else
+			mesgVal = Py_BuildValue("{s:(I,I,I)",
+			                        "angle_rate",
+                                    mesg[i].motionplus_mesg.angle_rate[CWIID_PHI],
+                                    mesg[i].motionplus_mesg.angle_rate[CWIID_THETA],
+                                    mesg[i].motionplus_mesg.angle_rate[CWIID_PSI]);
+#endif
                                     
 			break;
 		case CWIID_MESG_ERROR:

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,6 +1,10 @@
 from distutils.core import setup, Extension
 
-setup(name='cwiid',
-	version='0.7.00',
-	ext_modules=[Extension('cwiid', ['cwiidmodule.c', 'Wiimote.c'])]
-	)
+setup(
+    name='cwiid',
+    version='3.0.0',
+    description='Python3 module for libcwiid',
+    author='Azzra',
+    author_email='azzra@users.noreply.github.com',
+    ext_modules=[Extension('cwiid', ['cwiidmodule.c', 'Wiimote.c'], libraries=['cwiid', 'bluetooth'])]
+)


### PR DESCRIPTION
Since different Wiimotes have slightly different camera parameters, it is useful for scripts to be able to get the Wiimote bluetooth address in order to have different calibration for different Wiimotes. I do this in my [lightgun code](https://github.com/arpruss/cwiid-lightgun), for instance.