### PR TITLE
added missing #include statements

### DIFF
--- a/libcwiid/connect.c
+++ b/libcwiid/connect.c
@@ -72,7 +72,10 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <stdint.h>
 #include <bluetooth/bluetooth.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/hci_lib.h>
 #include <bluetooth/l2cap.h>
 #include "cwiid_internal.h"
 


### PR DESCRIPTION
Hello, I am maintaining cwiid as a debian package currently: https://qa.debian.org/developer.php?login=georgesk@debian.org#cwiid

As you were maintaining cwiid recently, I would like to reference your repository as an upstream source in the debian/watch file which helps me to keep things up to date.

please can you take my small changes in account, and add a git tag with a version number greater than 0.6.91, which is the version number of the latest debian release? You can use for example a tag like "v202401"; each time a greater tag is published, I get a reminder, and I make a debian package to keep in synch.

Thank you in advance!
